### PR TITLE
Use default export from `rollup-plugin-vue`

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,7 +1,7 @@
 const rollup = require("rollup");
 const nodeResolve = require("rollup-plugin-node-resolve");
 const commonjs = require("rollup-plugin-commonjs");
-const vue = require("rollup-plugin-vue");
+const vue = require("rollup-plugin-vue").default;
 const pkg = require("../package.json");
 
 const external = Object.keys(pkg.dependencies);


### PR DESCRIPTION
Current TypeScript config of the project (`rollup-plugin-vue`) does not create correct cjs bundles.